### PR TITLE
✨ feature[#6] : 한정판매 이벤트 전체 조회 api 

### DIFF
--- a/src/main/java/com/sparta/limited/limited_service/limited/application/dto/response/LimitedListResponse.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited/application/dto/response/LimitedListResponse.java
@@ -1,0 +1,34 @@
+package com.sparta.limited.limited_service.limited.application.dto.response;
+
+import com.sparta.limited.limited_service.limited.domain.model.Limited.LimitedStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class LimitedListResponse {
+
+    private final UUID id;
+    private final UUID limitedProductId;
+    private final String title;
+    private final LocalDateTime startDate;
+    private final LocalDateTime endDate;
+    private final LimitedStatus status;
+
+    private LimitedListResponse(UUID id, UUID limitedProductId, String title,
+        LocalDateTime startDate, LocalDateTime endDate, LimitedStatus status
+    ) {
+        this.id = id;
+        this.limitedProductId = limitedProductId;
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+    }
+
+    public static LimitedListResponse of(UUID id, UUID limitedProductId, String title,
+        LocalDateTime startDate, LocalDateTime endDate, LimitedStatus status) {
+        return new LimitedListResponse(id, limitedProductId, title, startDate, endDate, status);
+    }
+
+}

--- a/src/main/java/com/sparta/limited/limited_service/limited/application/mapper/LimitedMapper.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited/application/mapper/LimitedMapper.java
@@ -2,6 +2,7 @@ package com.sparta.limited.limited_service.limited.application.mapper;
 
 import com.sparta.limited.limited_service.limited.application.dto.request.LimitedCreateRequest;
 import com.sparta.limited.limited_service.limited.application.dto.response.LimitedCreateResponse;
+import com.sparta.limited.limited_service.limited.application.dto.response.LimitedListResponse;
 import com.sparta.limited.limited_service.limited.application.dto.response.LimitedProductResponse;
 import com.sparta.limited.limited_service.limited.application.dto.response.LimitedReadResponse;
 import com.sparta.limited.limited_service.limited.application.dto.response.LimitedResponse;
@@ -29,6 +30,14 @@ public class LimitedMapper {
         LimitedResponse limited, LimitedProductResponse limitedProduct) {
 
         return LimitedReadResponse.of(limited, limitedProduct);
+    }
+
+    public static LimitedListResponse toListResponse(
+        Limited limited, LimitedProductResponse limitedProduct) {
+
+        return LimitedListResponse.of(limited.getId(), limitedProduct.getId(),
+            limitedProduct.getTitle(), limited.getStartDate(), limited.getEndDate(),
+            limited.getStatus());
     }
 
 }

--- a/src/main/java/com/sparta/limited/limited_service/limited/application/mapper/LimitedMapper.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited/application/mapper/LimitedMapper.java
@@ -33,10 +33,10 @@ public class LimitedMapper {
     }
 
     public static LimitedListResponse toListResponse(
-        Limited limited, LimitedProductResponse limitedProduct) {
+        Limited limited, String title) {
 
-        return LimitedListResponse.of(limited.getId(), limitedProduct.getId(),
-            limitedProduct.getTitle(), limited.getStartDate(), limited.getEndDate(),
+        return LimitedListResponse.of(limited.getId(), limited.getLimitedProductId(),
+            title, limited.getStartDate(), limited.getEndDate(),
             limited.getStatus());
     }
 

--- a/src/main/java/com/sparta/limited/limited_service/limited/application/service/LimitedService.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited/application/service/LimitedService.java
@@ -58,14 +58,9 @@ public class LimitedService {
             limitedPage.stream().map(Limited::getLimitedProductId).distinct().toList());
 
         List<LimitedListResponse> responses = limitedPage.stream()
-            .map(limited -> LimitedListResponse.of(
-                limited.getId(),
-                limited.getLimitedProductId(),
-                limitedProductTitles.get(limited.getLimitedProductId()),
-                limited.getStartDate(),
-                limited.getEndDate(),
-                limited.getStatus()
-            )).toList();
+            .map(limited -> LimitedMapper.toListResponse(
+                limited, limitedProductTitles.get(limited.getLimitedProductId())))
+            .toList();
 
         return new PageImpl<>(responses, pageable, limitedPage.getTotalElements());
     }

--- a/src/main/java/com/sparta/limited/limited_service/limited/application/service/LimitedService.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited/application/service/LimitedService.java
@@ -2,6 +2,7 @@ package com.sparta.limited.limited_service.limited.application.service;
 
 import com.sparta.limited.limited_service.limited.application.dto.request.LimitedCreateRequest;
 import com.sparta.limited.limited_service.limited.application.dto.response.LimitedCreateResponse;
+import com.sparta.limited.limited_service.limited.application.dto.response.LimitedListResponse;
 import com.sparta.limited.limited_service.limited.application.dto.response.LimitedProductResponse;
 import com.sparta.limited.limited_service.limited.application.dto.response.LimitedReadResponse;
 import com.sparta.limited.limited_service.limited.application.dto.response.LimitedResponse;
@@ -9,8 +10,13 @@ import com.sparta.limited.limited_service.limited.application.mapper.LimitedMapp
 import com.sparta.limited.limited_service.limited.application.service.limited_product.LimitedProductFacade;
 import com.sparta.limited.limited_service.limited.domain.model.Limited;
 import com.sparta.limited.limited_service.limited.domain.repository.LimitedRepository;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,5 +47,26 @@ public class LimitedService {
             limited.getLimitedProductId());
 
         return LimitedMapper.toReadResponse(limitedResponse, limitedProductResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<LimitedListResponse> getLimitedEvents(Pageable pageable) {
+
+        Page<Limited> limitedPage = limitedRepository.findAll(pageable);
+
+        Map<UUID, String> limitedProductTitles = limitedProductFacade.getLimitedProductTitles(
+            limitedPage.stream().map(Limited::getLimitedProductId).distinct().toList());
+
+        List<LimitedListResponse> responses = limitedPage.stream()
+            .map(limited -> LimitedListResponse.of(
+                limited.getId(),
+                limited.getLimitedProductId(),
+                limitedProductTitles.get(limited.getLimitedProductId()),
+                limited.getStartDate(),
+                limited.getEndDate(),
+                limited.getStatus()
+            )).toList();
+
+        return new PageImpl<>(responses, pageable, limitedPage.getTotalElements());
     }
 }

--- a/src/main/java/com/sparta/limited/limited_service/limited/application/service/limited_product/LimitedProductFacade.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited/application/service/limited_product/LimitedProductFacade.java
@@ -3,7 +3,11 @@ package com.sparta.limited.limited_service.limited.application.service.limited_p
 import com.sparta.limited.limited_service.limited.application.dto.response.LimitedProductResponse;
 import com.sparta.limited.limited_service.limited_product.application.dto.response.LimitedProductReadResponse;
 import com.sparta.limited.limited_service.limited_product.application.service.LimitedProductService;
+import com.sparta.limited.limited_service.limited_product.domain.model.LimitedProduct;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +23,18 @@ public class LimitedProductFacade {
         return LimitedProductResponse.of(response.getId(), response.getProductId(),
             response.getTitle(),
             response.getDescription(), response.getPrice(), response.getQuantity());
+    }
+
+    public Map<UUID, String> getLimitedProductTitles(List<UUID> limitedProductIds) {
+
+        Map<UUID, LimitedProduct> map = limitedProductService.getLimitedProductsByids(
+            limitedProductIds);
+
+        return map.entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().getTitle()
+            ));
     }
 
 }

--- a/src/main/java/com/sparta/limited/limited_service/limited/domain/repository/LimitedRepository.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited/domain/repository/LimitedRepository.java
@@ -2,10 +2,14 @@ package com.sparta.limited.limited_service.limited.domain.repository;
 
 import com.sparta.limited.limited_service.limited.domain.model.Limited;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface LimitedRepository {
 
     void save(Limited limited);
 
     Limited findById(UUID limitedEventId);
+
+    Page<Limited> findAll(Pageable pageable);
 }

--- a/src/main/java/com/sparta/limited/limited_service/limited/infrastructure/repository/LimitedRepositoryImpl.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited/infrastructure/repository/LimitedRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.sparta.limited.limited_service.limited.domain.repository.LimitedRepos
 import com.sparta.limited.limited_service.limited.infrastructure.persistence.JpaLimitedRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -23,5 +25,10 @@ public class LimitedRepositoryImpl implements LimitedRepository {
     public Limited findById(UUID limitedEventId) {
         return jpaLimitedRepository.findById(limitedEventId)
             .orElseThrow(() -> new LimitedEventNotFoundException(limitedEventId));
+    }
+
+    @Override
+    public Page<Limited> findAll(Pageable pageable) {
+        return jpaLimitedRepository.findAll(pageable);
     }
 }

--- a/src/main/java/com/sparta/limited/limited_service/limited/presentation/controller/LimitedController.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited/presentation/controller/LimitedController.java
@@ -2,10 +2,14 @@ package com.sparta.limited.limited_service.limited.presentation.controller;
 
 import com.sparta.limited.limited_service.limited.application.dto.request.LimitedCreateRequest;
 import com.sparta.limited.limited_service.limited.application.dto.response.LimitedCreateResponse;
+import com.sparta.limited.limited_service.limited.application.dto.response.LimitedListResponse;
 import com.sparta.limited.limited_service.limited.application.dto.response.LimitedReadResponse;
 import com.sparta.limited.limited_service.limited.application.service.LimitedService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,6 +43,14 @@ public class LimitedController {
 
         LimitedReadResponse response = limitedService.getLimitedEvent(limitedEventId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<LimitedListResponse>> getLimitedEvents(
+        @PageableDefault() Pageable pageable) {
+
+        Page<LimitedListResponse> responses = limitedService.getLimitedEvents(pageable);
+        return ResponseEntity.ok(responses);
     }
 
 

--- a/src/main/java/com/sparta/limited/limited_service/limited_product/application/service/LimitedProductService.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited_product/application/service/LimitedProductService.java
@@ -9,6 +9,8 @@ import com.sparta.limited.limited_service.limited_product.application.service.pr
 import com.sparta.limited.limited_service.limited_product.application.service.product.dto.ProductInfo;
 import com.sparta.limited.limited_service.limited_product.domain.model.LimitedProduct;
 import com.sparta.limited.limited_service.limited_product.domain.repository.LimitedProductRepository;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -48,5 +50,9 @@ public class LimitedProductService {
 
         limitedProduct.updateQuantity();
         return LimitedProductMapper.toUpdateResponse(limitedProduct);
+    }
+
+    public Map<UUID, LimitedProduct> getLimitedProductsByids(List<UUID> limitedProductIds) {
+        return limitedProductRepository.findAllById(limitedProductIds);
     }
 }

--- a/src/main/java/com/sparta/limited/limited_service/limited_product/domain/repository/LimitedProductRepository.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited_product/domain/repository/LimitedProductRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.limited.limited_service.limited_product.domain.repository;
 
 import com.sparta.limited.limited_service.limited_product.domain.model.LimitedProduct;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface LimitedProductRepository {
@@ -8,4 +10,6 @@ public interface LimitedProductRepository {
     void save(LimitedProduct limitedProduct);
 
     LimitedProduct findById(UUID limitedProductId);
+
+    Map<UUID, LimitedProduct> findAllById(List<UUID> limitedProductIds);
 }

--- a/src/main/java/com/sparta/limited/limited_service/limited_product/infrastructure/repository/LimitedProductRepositoryImpl.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited_product/infrastructure/repository/LimitedProductRepositoryImpl.java
@@ -4,7 +4,11 @@ import com.sparta.limited.limited_service.limited_product.domain.exception.Limit
 import com.sparta.limited.limited_service.limited_product.domain.model.LimitedProduct;
 import com.sparta.limited.limited_service.limited_product.domain.repository.LimitedProductRepository;
 import com.sparta.limited.limited_service.limited_product.infrastructure.persistence.JpaLimitedProductRepository;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -23,5 +27,12 @@ public class LimitedProductRepositoryImpl implements LimitedProductRepository {
     public LimitedProduct findById(UUID limitedProductId) {
         return jpaLimitedProductRepository.findById(limitedProductId)
             .orElseThrow(() -> new LimitedProductNotFoundException(limitedProductId));
+    }
+
+    @Override
+    public Map<UUID, LimitedProduct> findAllById(List<UUID> limitedProductIds) {
+        return jpaLimitedProductRepository.findAllById(limitedProductIds)
+            .stream()
+            .collect(Collectors.toMap(LimitedProduct::getId, Function.identity()));
     }
 }

--- a/src/test/resources/http/limited-test.http
+++ b/src/test/resources/http/limited-test.http
@@ -32,3 +32,7 @@ X-User-Id: 123
 ### 한정수량 이벤트 단건 조회
 GET http://localhost:8080/api/v1/limited-events/0fb125a2-fb61-424e-95e0-1d9cf48687f4
 Content-Type: application/json
+
+### 한정수량 이벤트 전체 조회
+GET http://localhost:8080/api/v1/limited-events
+Content-Type: application/json


### PR DESCRIPTION

## ✨ 변경 타입
* [X] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [X] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [X] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 변경 내용
* 한정수량 판매 이벤트에 대한 전체 조회 api 구현 
  * 너무 무거운 정보를 담지 않도록, 이벤트 정보 + 한정수량 상품의 title 정도만 리스트 형태로 반환합니다.

* Controller, Service + Facade(애그리거트가 다른 서비스를 호출하여 값 반환), Repository, ListResponse, Mapper 를 구현했습니다.
* 추가로 한정 상품 서비스에서 한 번에 DB조회 후 반환해주기 위해 Service, Repository를 추가 구현했습니다.

* 자세한 내용은 커밋 메세지 확인 부탁드려요!!
