### PR TITLE
✨enhancement [#39] 한정판매 구매시 실패 응답 처리 속도 향상 로직 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=docker
     mem_limit: 1024mb
-    cpus: 0.5
+    cpus: 1
     networks:
       - limited-team25
 

--- a/src/main/java/com/sparta/limited/limited_service/limited_product/infrastructure/persistence/JpaLimitedProductRepository.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited_product/infrastructure/persistence/JpaLimitedProductRepository.java
@@ -14,5 +14,8 @@ public interface JpaLimitedProductRepository extends JpaRepository<LimitedProduc
     @Query("select p from LimitedProduct p where p.id = :id")
     Optional<LimitedProduct> findByIdWithLock(UUID id);
 
+    @Query("select count(p) > 0 from LimitedProduct p where p.id = :id and p.quantity > 0")
+    boolean existsQuantityGreaterThanZero(UUID id);
+
     Optional<LimitedProduct> findByProductId(UUID productId);
 }

--- a/src/main/java/com/sparta/limited/limited_service/limited_product/infrastructure/repository/LimitedProductRepositoryImpl.java
+++ b/src/main/java/com/sparta/limited/limited_service/limited_product/infrastructure/repository/LimitedProductRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.sparta.limited.limited_service.limited_product.infrastructure.repository;
 
+import com.sparta.limited.limited_service.limited_product.domain.exception.LimitedProductNoQuantityException;
 import com.sparta.limited.limited_service.limited_product.domain.exception.LimitedProductNotFoundException;
 import com.sparta.limited.limited_service.limited_product.domain.model.LimitedProduct;
 import com.sparta.limited.limited_service.limited_product.domain.repository.LimitedProductRepository;
@@ -28,6 +29,10 @@ public class LimitedProductRepositoryImpl implements LimitedProductRepository {
 
     @Override
     public LimitedProduct findByIdWithLock(UUID limitedProductId) {
+        if (!jpaLimitedProductRepository.existsQuantityGreaterThanZero(limitedProductId)) {
+            throw new LimitedProductNoQuantityException(limitedProductId);
+        }
+
         return jpaLimitedProductRepository.findByIdWithLock(limitedProductId)
             .orElseThrow(() -> new LimitedProductNotFoundException(limitedProductId));
     }


### PR DESCRIPTION
## ✨ 변경 타입
* [X] 신규 기능 추가/수정
* [ ] 버그 수정
* [X] 리팩토링
* [X] 설정
* [X] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?

## 🚀 변경 내용
* **as-is**
  * 한정판매 구매시 재고 조회 및 감소시 비관적 락을 걸어 한 번에 처리하는 기능만 구현 

* **to-be**
  * 비관적 락이 적용된 재고 조회 및 감소 이전에 기능을 하나 추가
  * 재고가 남아있는지만 판단하여 boolean값으로 반환해주는 로직을 추가하여 실패 응답 처리 속도 향상

* + 도커 cpus 수정했습니다.

## 💡 추가 설명

* 빠르게 예외처리를 할 수 있도록 로직을 추가했습니다!
* 재고가 많아질수록 성능이 더 안좋아질 수 있어 추후 Redis 도입이 필요합니다!
* 재고가 100~1000개 이하는 재고 없음 처리가 많아 해당 기능 적용 후 유의미한 결과를 보였습니다!
